### PR TITLE
fix fish and stomach incorrectly inheriting from flesh

### DIFF
--- a/items/comestible.json
+++ b/items/comestible.json
@@ -33,7 +33,7 @@
   },
   {
     "id": "stomach",
-    "copy-from": "flesh",
+    "copy-from": "stomach",
     "type": "COMESTIBLE",
     "name": "stomach",
     "description": "The stomach of a woodland creature.  It is surprisingly durable. [3/10 rad]",
@@ -49,7 +49,7 @@
   },
   {
     "id": "fish",
-    "copy-from": "flesh",
+    "copy-from": "fish",
     "type": "COMESTIBLE",
     "name": "fillet of fish",
     "name_plural": "fillets of fish",


### PR DESCRIPTION
Fish and stomach incorrectly inherited from "flesh". This caused a crash upon butchering a fish and scrubbed Stomach of any identifying characteristics.