### PR TITLE
Update pk_recipe.json battery_atomic

### DIFF
--- a/pk_recipe.json
+++ b/pk_recipe.json
@@ -1168,7 +1168,7 @@
     "book_learn": [ [ "recipe_lab_elec", 1 ], [ "textbook_robots", 1 ] ],
     "qualities": [ { "id": "SCREW", "level": 1, "amount": 1 } ],
     "tools": [ [ [ "soldering_iron", 28 ], [ "toolset", 28 ] ] ],
-    "components": [ [ [ "shockcannon", 1 ] ], [ [ "battery_atomic", 1 ] ], [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "shockcannon", 1 ] ], [ [ "light_atomic_battery_cell", 1 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
I don't know when light_atomic_battery_cell replaced battery_atomic though. but this should match latest experimentals.